### PR TITLE
refactor(structure): reorganize packages to improve domain clarity #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,17 +217,26 @@ N/A - Documentation changes only
 
 
 
+
 <!-- coverage start -->
 ## 📊 Code Coverage Report
 
-**Overall Coverage: 100.00% ✅**
+**Overall Coverage: 0% ⚠️**
 
 | Metric      | Covered | Missed | Total | Coverage |
 |-------------|---------|--------|--------|----------|
-| INSTRUCTION | 1015 | 0 | 1015 | 100.00% ✅ |
-| LINE | 299 | 0 | 299 | 100.00% ✅ |
-| BRANCH | 8 | 0 | 8 | 100.00% ✅ |
-| METHOD | 71 | 0 | 71 | 100.00% ✅ |
-| CLASS | 11 | 0 | 11 | 100.00% ✅ |
-| COMPLEXITY | 75 | 0 | 75 | 100.00% ✅ |
+| INSTRUCTION |  |  | 0 | 0% ⚠️ |
+| LINE |  |  | 0 | 0% ⚠️ |
+| BRANCH |  |  | 0 | 0% ⚠️ |
+| METHOD |  |  | 0 | 0% ⚠️ |
+| CLASS |  |  | 0 | 0% ⚠️ |
+| COMPLEXITY |  |  | 0 | 0% ⚠️ |
+
+### 🚨 Least Tested Elements (coverage below 50%)
+- INSTRUCTION: 0%
+- LINE: 0%
+- BRANCH: 0%
+- METHOD: 0%
+- CLASS: 0%
+- COMPLEXITY: 0%
 <!-- coverage end -->

--- a/src/main/java/com/kenyajug/regression/application/Application.java
+++ b/src/main/java/com/kenyajug/regression/application/Application.java
@@ -1,4 +1,4 @@
-package com.kenyajug.regression.entities;
+package com.kenyajug.regression.application;
 
 import java.time.LocalDateTime;
 
@@ -25,11 +25,12 @@ import java.time.LocalDateTime;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-public record User(
-        String uuid,
-        String username,
-        String password,
-        String roles_list_json,
-        LocalDateTime created_at
+public record Application(
+       String uuid,
+       String name,
+       String appVersion,
+       String runtimeEnvironment,
+       String owner,
+       LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/kenyajug/regression/application/ApplicationManager.java
+++ b/src/main/java/com/kenyajug/regression/application/ApplicationManager.java
@@ -1,0 +1,5 @@
+package com.kenyajug.regression.application;
+
+public class ApplicationManager {
+
+}

--- a/src/main/java/com/kenyajug/regression/application/ApplicationsRepository.java
+++ b/src/main/java/com/kenyajug/regression/application/ApplicationsRepository.java
@@ -1,29 +1,6 @@
-package com.kenyajug.regression.repository;
-/*
- * MIT License
- *
- * Copyright (c) 2025 Kenya JUG
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-import com.kenyajug.regression.entities.Application;
-import com.kenyajug.regression.entities.User;
+package com.kenyajug.regression.application;
+import com.kenyajug.regression.common.CrudRepository;
+import com.kenyajug.regression.user.User;
 import com.kenyajug.regression.utils.DateTimeUtils;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
@@ -32,7 +9,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 @Repository
-public non-sealed class ApplicationsRepository implements CrudRepository<Application>{
+public class ApplicationsRepository implements CrudRepository<Application>{
     private final JdbcClient jdbcClient;
     private final TransactionTemplate transactionTemplate;
     public ApplicationsRepository(JdbcClient jdbcClient, TransactionTemplate transactionTemplate) {

--- a/src/main/java/com/kenyajug/regression/common/CrudRepository.java
+++ b/src/main/java/com/kenyajug/regression/common/CrudRepository.java
@@ -1,4 +1,4 @@
-package com.kenyajug.regression.repository;
+package com.kenyajug.regression.common;
 /*
  * MIT License
  *
@@ -26,14 +26,14 @@ package com.kenyajug.regression.repository;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+
 /**
  * A generic CRUD (Create, Read, Update, Delete) repository interface
  * for performing basic database operations on any entity type.
  *
  * @param <T> the type of the entity managed by this repository
  */
-public sealed interface CrudRepository<T>
-        permits AppLogRepository, ApplicationsRepository, LogsMetadataRepository, UserRepository
+public interface CrudRepository<T>
 {
 
     /**

--- a/src/main/java/com/kenyajug/regression/logger/Logger.java
+++ b/src/main/java/com/kenyajug/regression/logger/Logger.java
@@ -1,0 +1,5 @@
+package com.kenyajug.regression.logger;
+
+public interface Logger {
+
+}

--- a/src/main/java/com/kenyajug/regression/logger/impl/DatabaseLogger.java
+++ b/src/main/java/com/kenyajug/regression/logger/impl/DatabaseLogger.java
@@ -1,0 +1,7 @@
+package com.kenyajug.regression.logger.impl;
+
+import com.kenyajug.regression.logger.Logger;
+
+public class DatabaseLogger implements Logger {
+
+}

--- a/src/main/java/com/kenyajug/regression/logger/model/Log.java
+++ b/src/main/java/com/kenyajug/regression/logger/model/Log.java
@@ -1,6 +1,5 @@
-package com.kenyajug.regression.entities;
+package com.kenyajug.regression.logger.model;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 /*
@@ -26,7 +25,7 @@ import java.time.LocalDateTime;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-public record AppLog(
+public record Log(
         String uuid,
         LocalDateTime timestamp,
         String severity,

--- a/src/main/java/com/kenyajug/regression/logger/model/LogMetadata.java
+++ b/src/main/java/com/kenyajug/regression/logger/model/LogMetadata.java
@@ -1,4 +1,4 @@
-package com.kenyajug.regression.entities;
+package com.kenyajug.regression.logger.model;
 /*
  * MIT License
  *
@@ -22,7 +22,7 @@ package com.kenyajug.regression.entities;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-public record LogsMetadata(
+public record LogMetadata(
         String uuid,
         String logId,
         String metadataType,

--- a/src/main/java/com/kenyajug/regression/logger/repository/LogMetadataRepository.java
+++ b/src/main/java/com/kenyajug/regression/logger/repository/LogMetadataRepository.java
@@ -1,30 +1,7 @@
-package com.kenyajug.regression.repository;
-/*
- * MIT License
- *
- * Copyright (c) 2025 Kenya JUG
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-import com.kenyajug.regression.entities.Application;
-import com.kenyajug.regression.entities.LogsMetadata;
-import com.kenyajug.regression.utils.DateTimeUtils;
+package com.kenyajug.regression.logger.repository;
+import com.kenyajug.regression.common.CrudRepository;
+import com.kenyajug.regression.logger.model.LogMetadata;
+
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -32,10 +9,10 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 @Repository
-public non-sealed class LogsMetadataRepository implements CrudRepository<LogsMetadata>{
+public class LogMetadataRepository implements CrudRepository<LogMetadata>{
     private final JdbcClient jdbcClient;
     private final TransactionTemplate transactionTemplate;
-    public LogsMetadataRepository(JdbcClient jdbcClient, TransactionTemplate transactionTemplate) {
+    public LogMetadataRepository(JdbcClient jdbcClient, TransactionTemplate transactionTemplate) {
         this.jdbcClient = jdbcClient;
         this.transactionTemplate = transactionTemplate;
     }
@@ -46,7 +23,7 @@ public non-sealed class LogsMetadataRepository implements CrudRepository<LogsMet
      * @param entity the entity to save (must not be {@code null})
      */
     @Override
-    public void save(LogsMetadata entity) {
+    public void save(LogMetadata entity) {
         transactionTemplate.executeWithoutResult(status -> {
             var insertSql = """
                  INSERT INTO logs_metadata (
@@ -78,7 +55,7 @@ public non-sealed class LogsMetadataRepository implements CrudRepository<LogsMet
      * @return an {@link Optional} containing the found entity, or empty if not found
      */
     @Override
-    public Optional<LogsMetadata> findById(String uuid) {
+    public Optional<LogMetadata> findById(String uuid) {
         var selectSql = """
                 SELECT * FROM logs_metadata
                 WHERE uuid = :uuid
@@ -86,7 +63,7 @@ public non-sealed class LogsMetadataRepository implements CrudRepository<LogsMet
                 """;
         return jdbcClient.sql(selectSql)
                 .param("uuid",uuid)
-                .query((resultSet, row) -> new LogsMetadata(
+                .query((resultSet, row) -> new LogMetadata(
                         resultSet.getString("uuid"),
                         resultSet.getString("log_uuid"),
                         resultSet.getString("metadata_type"),
@@ -100,13 +77,13 @@ public non-sealed class LogsMetadataRepository implements CrudRepository<LogsMet
      * @return a list of all entities; never {@code null}, but may be empty
      */
     @Override
-    public List<LogsMetadata> findAll() {
+    public List<LogMetadata> findAll() {
         var selectSql = """
                 SELECT * FROM logs_metadata
                 ;
                 """;
         return jdbcClient.sql(selectSql)
-                .query((resultSet, row) -> new LogsMetadata(
+                .query((resultSet, row) -> new LogMetadata(
                         resultSet.getString("uuid"),
                         resultSet.getString("log_uuid"),
                         resultSet.getString("metadata_type"),
@@ -172,7 +149,7 @@ public non-sealed class LogsMetadataRepository implements CrudRepository<LogsMet
      * @throws NoSuchElementException   if no entity with the given {@code uuid} exists in the data source
      */
     @Override
-    public void updateById(String uuid, LogsMetadata entity) throws NoSuchElementException {
+    public void updateById(String uuid, LogMetadata entity) throws NoSuchElementException {
         var updateSql = """
                 UPDATE logs_metadata
                 SET log_uuid = :log_uuid,
@@ -188,7 +165,7 @@ public non-sealed class LogsMetadataRepository implements CrudRepository<LogsMet
                 .param("uuid",uuid)
                 .update();
     }
-    public List<LogsMetadata> findByRootLogId(String parentLogId) {
+    public List<LogMetadata> findByRootLogId(String parentLogId) {
         var selectSql = """
                 SELECT * FROM logs_metadata
                 WHERE log_uuid = :log_uuid
@@ -196,7 +173,7 @@ public non-sealed class LogsMetadataRepository implements CrudRepository<LogsMet
                 """;
         return jdbcClient.sql(selectSql)
                 .param("log_uuid",parentLogId)
-                .query((resultSet, row) -> new LogsMetadata(
+                .query((resultSet, row) -> new LogMetadata(
                         resultSet.getString("uuid"),
                         resultSet.getString("log_uuid"),
                         resultSet.getString("metadata_type"),

--- a/src/main/java/com/kenyajug/regression/logger/repository/LogRepository.java
+++ b/src/main/java/com/kenyajug/regression/logger/repository/LogRepository.java
@@ -1,28 +1,6 @@
-package com.kenyajug.regression.repository;
-/*
- * MIT License
- *
- * Copyright (c) 2025 Kenya JUG
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-import com.kenyajug.regression.entities.AppLog;
+package com.kenyajug.regression.logger.repository;
+import com.kenyajug.regression.common.CrudRepository;
+import com.kenyajug.regression.logger.model.Log;
 import com.kenyajug.regression.utils.DateTimeUtils;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
@@ -31,10 +9,10 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 @Repository
-public non-sealed class AppLogRepository implements CrudRepository<AppLog>{
+public class LogRepository implements CrudRepository<Log>{
     private final JdbcClient jdbcClient;
     private final TransactionTemplate transactionTemplate;
-    public AppLogRepository(JdbcClient jdbcClient, TransactionTemplate transactionTemplate) {
+    public LogRepository(JdbcClient jdbcClient, TransactionTemplate transactionTemplate) {
         this.jdbcClient = jdbcClient;
         this.transactionTemplate = transactionTemplate;
     }
@@ -45,7 +23,7 @@ public non-sealed class AppLogRepository implements CrudRepository<AppLog>{
      * @param entity the entity to save (must not be {@code null})
      */
     @Override
-    public void save(AppLog entity) {
+    public void save(Log entity) {
         transactionTemplate.executeWithoutResult(status -> {
             var insertSql = """
                          INSERT INTO app_logs (
@@ -82,7 +60,7 @@ public non-sealed class AppLogRepository implements CrudRepository<AppLog>{
      * @return an {@link Optional} containing the found entity, or empty if not found
      */
     @Override
-    public Optional<AppLog> findById(String uuid) {
+    public Optional<Log> findById(String uuid) {
         var selectSql = """
                 SELECT * FROM app_logs
                 WHERE uuid = :uuid
@@ -90,7 +68,7 @@ public non-sealed class AppLogRepository implements CrudRepository<AppLog>{
                 """;
         return jdbcClient.sql(selectSql)
                 .param("uuid",uuid)
-                .query((resultSet, row) -> new AppLog(
+                .query((resultSet, row) -> new Log(
                         resultSet.getString("uuid"),
                         DateTimeUtils.convertZonedUTCTimeStringToLocalDateTime(resultSet.getString("timestamp")),
                         resultSet.getString("severity"),
@@ -106,13 +84,13 @@ public non-sealed class AppLogRepository implements CrudRepository<AppLog>{
      * @return a list of all entities; never {@code null}, but may be empty
      */
     @Override
-    public List<AppLog> findAll() {
+    public List<Log> findAll() {
         var selectSql = """
                 SELECT * FROM app_logs
                 ;
                 """;
         return jdbcClient.sql(selectSql)
-                .query((resultSet, row) -> new AppLog(
+                .query((resultSet, row) -> new Log(
                         resultSet.getString("uuid"),
                         DateTimeUtils.convertZonedUTCTimeStringToLocalDateTime(resultSet.getString("timestamp")),
                         resultSet.getString("severity"),
@@ -180,7 +158,7 @@ public non-sealed class AppLogRepository implements CrudRepository<AppLog>{
      * @throws NoSuchElementException   if no entity with the given {@code uuid} exists in the data source
      */
     @Override
-    public void updateById(String uuid, AppLog entity) throws NoSuchElementException {
+    public void updateById(String uuid, Log entity) throws NoSuchElementException {
         var updateSql = """
                 UPDATE app_logs
                 SET timestamp = :timestamp,

--- a/src/main/java/com/kenyajug/regression/user/User.java
+++ b/src/main/java/com/kenyajug/regression/user/User.java
@@ -1,6 +1,5 @@
-package com.kenyajug.regression.entities;
+package com.kenyajug.regression.user;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 /*
@@ -26,12 +25,11 @@ import java.time.LocalDateTime;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-public record Application(
-       String uuid,
-       String name,
-       String appVersion,
-       String runtimeEnvironment,
-       String owner,
-       LocalDateTime createdAt
+public record User(
+        String uuid,
+        String username,
+        String password,
+        String roles_list_json,
+        LocalDateTime created_at
 ) {
 }

--- a/src/main/java/com/kenyajug/regression/user/UserManager.java
+++ b/src/main/java/com/kenyajug/regression/user/UserManager.java
@@ -1,0 +1,5 @@
+package com.kenyajug.regression.user;
+
+public class UserManager {
+
+}

--- a/src/main/java/com/kenyajug/regression/user/UserRepository.java
+++ b/src/main/java/com/kenyajug/regression/user/UserRepository.java
@@ -1,28 +1,5 @@
-package com.kenyajug.regression.repository;
-/*
- * MIT License
- *
- * Copyright (c) 2025 Kenya JUG
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-import com.kenyajug.regression.entities.User;
+package com.kenyajug.regression.user;
+import com.kenyajug.regression.common.CrudRepository;
 import com.kenyajug.regression.utils.DateTimeUtils;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
@@ -30,7 +7,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 import java.util.List;
 import java.util.Optional;
 @Repository
-public non-sealed class UserRepository implements CrudRepository<User> {
+public class UserRepository implements CrudRepository<User> {
     private final JdbcClient jdbcClient;
     private final TransactionTemplate transactionTemplate;
     public UserRepository(JdbcClient jdbcClient, TransactionTemplate transactionTemplate) {

--- a/src/test/java/com/kenyajug/regression/persistence_tests/ApplicationRepositoryTest.java
+++ b/src/test/java/com/kenyajug/regression/persistence_tests/ApplicationRepositoryTest.java
@@ -1,33 +1,9 @@
 package com.kenyajug.regression.persistence_tests;
-/*
- * MIT License
- *
- * Copyright (c) 2025 Kenya JUG
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-import com.kenyajug.regression.entities.Application;
-import com.kenyajug.regression.entities.User;
-import com.kenyajug.regression.repository.ApplicationsRepository;
+import com.kenyajug.regression.application.Application;
+import com.kenyajug.regression.application.ApplicationsRepository;
+import com.kenyajug.regression.user.User;
 import com.kenyajug.regression.utils.DateTimeUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -39,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 @Transactional
 @TestPropertySource(locations = "classpath:application-test.properties")
-public class ApplicationsRepositoryTest {
+public class ApplicationRepositoryTest {
     @Autowired
     private JdbcClient jdbcClient;
     @Autowired

--- a/src/test/java/com/kenyajug/regression/persistence_tests/LogMetadataRepositoryTest.java
+++ b/src/test/java/com/kenyajug/regression/persistence_tests/LogMetadataRepositoryTest.java
@@ -1,31 +1,8 @@
 package com.kenyajug.regression.persistence_tests;
-/*
- * MIT License
- *
- * Copyright (c) 2025 Kenya JUG
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-import com.kenyajug.regression.entities.LogsMetadata;
-import com.kenyajug.regression.repository.LogsMetadataRepository;
+import com.kenyajug.regression.logger.model.LogMetadata;
+import com.kenyajug.regression.logger.repository.LogMetadataRepository;
+
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -37,11 +14,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 @Transactional
 @TestPropertySource(locations = "classpath:application-test.properties")
-public class LogsMetadataRepositoryTest {
+public class LogMetadataRepositoryTest {
     @Autowired
     private JdbcClient jdbcClient;
     @Autowired
-    private LogsMetadataRepository repository;
+    private LogMetadataRepository repository;
     private final String logId = "Root_log_UUID1";
     @AfterEach
     public void cleanUp(){
@@ -52,7 +29,7 @@ public class LogsMetadataRepositoryTest {
     }
     @Test
     public void shouldSaveObjectTest(){
-        var entity = new LogsMetadata(
+        var entity = new LogMetadata(
                 "UUID1",
                 logId,
                 "OS",
@@ -69,12 +46,12 @@ public class LogsMetadataRepositoryTest {
     }
     @Test
     public void shouldFindAllObjectsTest(){
-        var entity1 = new LogsMetadata(
+        var entity1 = new LogMetadata(
                 "UUID1",
                 logId,
                 "OS",
                 "Ubuntu Desktop 24.04.2 LTS");
-        var entity2 = new LogsMetadata(
+        var entity2 = new LogMetadata(
                 "UUID2",
                 logId,
                 "OS",
@@ -84,7 +61,7 @@ public class LogsMetadataRepositoryTest {
         var users = repository.findAll();
         assertThat(users).isNotEmpty();
         var persistedOptional = users.stream()
-                .sorted(Comparator.comparing(LogsMetadata::uuid))
+                .sorted(Comparator.comparing(LogMetadata::uuid))
                 .findFirst();
         assertThat(persistedOptional).isNotEmpty();
         var persisted = persistedOptional.get();
@@ -96,7 +73,7 @@ public class LogsMetadataRepositoryTest {
     }
     @Test
     public void shouldDeleteByIdTest(){
-        var entity = new LogsMetadata(
+        var entity = new LogMetadata(
                 "UUID1",
                 logId,
                 "OS",
@@ -113,12 +90,12 @@ public class LogsMetadataRepositoryTest {
     }
     @Test
     public void shouldDeleteAllObjectsTest(){
-        var entity1 = new LogsMetadata(
+        var entity1 = new LogMetadata(
                 "UUID1",
                 logId,
                 "OS",
                 "Ubuntu Desktop 24.04.2 LTS");
-        var entity2 = new LogsMetadata(
+        var entity2 = new LogMetadata(
                 "UUID2",
                 logId,
                 "OS",
@@ -128,7 +105,7 @@ public class LogsMetadataRepositoryTest {
         var entities = repository.findAll();
         assertThat(entities).isNotEmpty();
         var persistedOptional = entities.stream()
-                .sorted(Comparator.comparing(LogsMetadata::uuid))
+                .sorted(Comparator.comparing(LogMetadata::uuid))
                 .findFirst();
         assertThat(persistedOptional).isNotEmpty();
         var persisted = persistedOptional.get();
@@ -140,7 +117,7 @@ public class LogsMetadataRepositoryTest {
     }
     @Test
     public void shouldCheckObjectExistenceById_Test(){
-        var entity = new LogsMetadata(
+        var entity = new LogMetadata(
                 "UUID1",
                 logId,
                 "OS",
@@ -154,7 +131,7 @@ public class LogsMetadataRepositoryTest {
     }
     @Test
     public void shouldUpdateObjectTest(){
-        var entity = new LogsMetadata(
+        var entity = new LogMetadata(
                 "UUID1",
                 logId,
                 "OS",
@@ -162,7 +139,7 @@ public class LogsMetadataRepositoryTest {
         repository.save(entity);
         var exists = repository.existsById(entity.uuid());
         assertThat(exists).isTrue();
-        var entityUpdated = new LogsMetadata(
+        var entityUpdated = new LogMetadata(
                 "UUID1",
                 logId,
                 "OS",
@@ -179,12 +156,12 @@ public class LogsMetadataRepositoryTest {
     }
     @Test
     public void shouldFindLogsMetadataByParentLogTest(){
-        var entity1 = new LogsMetadata(
+        var entity1 = new LogMetadata(
                 "UUID1",
                 logId,
                 "OS",
                 "Ubuntu Desktop 24.04.2 LTS");
-        var entity2 = new LogsMetadata(
+        var entity2 = new LogMetadata(
                 "UUID2",
                 "LOG_UUID_2",
                 "OS",

--- a/src/test/java/com/kenyajug/regression/persistence_tests/LogRepositoryTest.java
+++ b/src/test/java/com/kenyajug/regression/persistence_tests/LogRepositoryTest.java
@@ -1,32 +1,8 @@
 package com.kenyajug.regression.persistence_tests;
-/*
- * MIT License
- *
- * Copyright (c) 2025 Kenya JUG
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-import com.kenyajug.regression.entities.AppLog;
-import com.kenyajug.regression.repository.AppLogRepository;
+import com.kenyajug.regression.logger.model.Log;
+import com.kenyajug.regression.logger.repository.LogRepository;
 import com.kenyajug.regression.utils.DateTimeUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -38,11 +14,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 @Transactional
 @TestPropertySource(locations = "classpath:application-test.properties")
-public class AppLogRepositoryTest {
+public class LogRepositoryTest {
     @Autowired
     private JdbcClient jdbcClient;
     @Autowired
-    private AppLogRepository repository;
+    private LogRepository repository;
     private final String appId = "APP_UUID1";
     @AfterEach
     public void cleanUp(){
@@ -53,7 +29,7 @@ public class AppLogRepositoryTest {
     }
     @Test
     public void shouldSaveObjectTest(){
-        var entity = new AppLog(
+        var entity = new Log(
                 "UUID1",
                 DateTimeUtils.convertZonedUTCTimeStringToLocalDateTime("2025-08-11 11:09:22 UTC"),
                 "WARN",
@@ -75,7 +51,7 @@ public class AppLogRepositoryTest {
     }
     @Test
     public void shouldFindAllObjectsTest(){
-        var entity1 = new AppLog(
+        var entity1 = new Log(
                 "UUID1",
                 DateTimeUtils.convertZonedUTCTimeStringToLocalDateTime("2025-08-11 11:09:22 UTC"),
                 "WARN",
@@ -83,7 +59,7 @@ public class AppLogRepositoryTest {
                 "Chrome LTS  version 132.0.6834.223",
                 "Object not found exception"
         );
-        var entity2 = new AppLog(
+        var entity2 = new Log(
                 "UUID2",
                 DateTimeUtils.convertZonedUTCTimeStringToLocalDateTime("2025-08-11 11:09:22 UTC"),
                 "WARN",
@@ -96,7 +72,7 @@ public class AppLogRepositoryTest {
         var users = repository.findAll();
         assertThat(users).isNotEmpty();
         var persistedOptional = users.stream()
-                .sorted(Comparator.comparing(AppLog::uuid))
+                .sorted(Comparator.comparing(Log::uuid))
                 .findFirst();
         assertThat(persistedOptional).isNotEmpty();
         var persisted = persistedOptional.get();
@@ -110,7 +86,7 @@ public class AppLogRepositoryTest {
     }
     @Test
     public void shouldDeleteByIdTest(){
-        var entity = new AppLog(
+        var entity = new Log(
                 "UUID1",
                 DateTimeUtils.convertZonedUTCTimeStringToLocalDateTime("2025-08-11 11:09:22 UTC"),
                 "WARN",
@@ -130,7 +106,7 @@ public class AppLogRepositoryTest {
     }
     @Test
     public void shouldDeleteAllObjectsTest(){
-        var entity1 = new AppLog(
+        var entity1 = new Log(
                 "UUID1",
                 DateTimeUtils.convertZonedUTCTimeStringToLocalDateTime("2025-08-11 11:09:22 UTC"),
                 "WARN",
@@ -138,7 +114,7 @@ public class AppLogRepositoryTest {
                 "Chrome LTS  version 132.0.6834.223",
                 "Object not found exception"
         );
-        var entity2 = new AppLog(
+        var entity2 = new Log(
                 "UUID2",
                 DateTimeUtils.convertZonedUTCTimeStringToLocalDateTime("2025-08-11 11:09:22 UTC"),
                 "WARN",
@@ -151,7 +127,7 @@ public class AppLogRepositoryTest {
         var entities = repository.findAll();
         assertThat(entities).isNotEmpty();
         var persistedOptional = entities.stream()
-                .sorted(Comparator.comparing(AppLog::uuid))
+                .sorted(Comparator.comparing(Log::uuid))
                 .findFirst();
         assertThat(persistedOptional).isNotEmpty();
         var persisted = persistedOptional.get();
@@ -163,7 +139,7 @@ public class AppLogRepositoryTest {
     }
     @Test
     public void shouldCheckObjectExistenceById_Test(){
-        var entity = new AppLog(
+        var entity = new Log(
                 "UUID1",
                 DateTimeUtils.convertZonedUTCTimeStringToLocalDateTime("2025-08-11 11:09:22 UTC"),
                 "WARN",
@@ -180,7 +156,7 @@ public class AppLogRepositoryTest {
     }
     @Test
     public void shouldUpdateObjectTest(){
-        var entity = new AppLog(
+        var entity = new Log(
                 "UUID1",
                 DateTimeUtils.convertZonedUTCTimeStringToLocalDateTime("2025-08-11 11:09:22 UTC"),
                 "WARN",
@@ -191,7 +167,7 @@ public class AppLogRepositoryTest {
         repository.save(entity);
         var exists = repository.existsById(entity.uuid());
         assertThat(exists).isTrue();
-        var entityUpdated = new AppLog(
+        var entityUpdated = new Log(
                 "UUID1",
                 DateTimeUtils.convertZonedUTCTimeStringToLocalDateTime("2025-08-11 11:09:22 UTC"),
                 "ERROR",

--- a/src/test/java/com/kenyajug/regression/persistence_tests/UserRepositoryTest.java
+++ b/src/test/java/com/kenyajug/regression/persistence_tests/UserRepositoryTest.java
@@ -1,32 +1,8 @@
 package com.kenyajug.regression.persistence_tests;
-/*
- * MIT License
- *
- * Copyright (c) 2025 Kenya JUG
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-import com.kenyajug.regression.entities.User;
-import com.kenyajug.regression.repository.UserRepository;
+import com.kenyajug.regression.user.User;
+import com.kenyajug.regression.user.UserRepository;
 import com.kenyajug.regression.utils.DateTimeUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
- Moved domain-specific classes to dedicated packages:
  - application/: Application, ApplicationManager, ApplicationsRepository
  - logger/: Logger interface, model (Log, LogMetadata), repository, impls
  - user/: User, UserManager, UserRepository
  - common/: Shared CrudRepository
- Renamed for consistency:
  - AppLog -> Log
  - LogsMetadata -> LogMetadata
  - Repositories  follow XxxRepository pattern

BREAKING CHANGE:
- Import paths changed for moved classes (e.g., CrudRepository now in common package)

The sub packages could change as the application grows depending on the number of sub classes needing to be grouped together. Also if there is anything wrong with the structure kindly may it be mentioned. I believe the structure at this stage is subject to change.

For the UI part, I haven't thought thorough about it. Since the application will receive logs also via exposing endpoints, I would like to hear ideas of the same. Should we have `controller` classes in the specific/respective packages for `restful api` and have `ui` package for controllers being consumed by thymelaf? Or should we have a `web/ui` for thymleaf controllers and `web/rest` for external api? 